### PR TITLE
Change error to warning

### DIFF
--- a/precisenumbers/__init__.py
+++ b/precisenumbers/__init__.py
@@ -49,6 +49,7 @@ class PreciseNumber:
     """Representation of a number that has a value and a precision, i.e., the number of valid
     digits after the decimal."""
 
+    PRECISION_WARNING: bool = True
     MAXIMUM_PRECISION: Optional[int] = None
     MAXIMUM: Optional[Union[float, int]] = None
     MINIMUM: Optional[Union[float, int]] = None
@@ -85,9 +86,10 @@ class PreciseNumber:
             self.MAXIMUM_PRECISION is not None
             and self.precision > self.MAXIMUM_PRECISION
         ):
-            raise ValueError(
-                f'precision exceeds maximum allowable value; precision must be <= {self.MAXIMUM_PRECISION}'
+            logger.warning(
+                f'precision exceeds maximum allowable value, which may indicate errors in data; this warning will not repeat'
             )
+            self.PRECISION_WARNING = False
 
         if (self.MINIMUM is not None and float(self) < self.MINIMUM) or (
             self.MAXIMUM is not None and float(self) > self.MAXIMUM

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -17,8 +17,12 @@ def test_Longitude_init():
     with pytest.raises(ValueError):
         precisecoordinates.Longitude(-180.3)
 
-    with pytest.raises(ValueError):
-        precisecoordinates.Longitude(-10.3, precision=8)
+
+def test_Longitude_warning(caplog):
+    precisecoordinates.Latitude(-10.3, precision=8)
+    assert 'WARNING' in caplog.text
+    assert 'precision exceeds maximum allowable value' in caplog.text
+
 
 def test_Latitude_init():
     # Success case
@@ -34,8 +38,11 @@ def test_Latitude_init():
     with pytest.raises(ValueError):
         precisecoordinates.Latitude(-90.3)
 
-    with pytest.raises(ValueError):
-        precisecoordinates.Latitude(-10.3, precision=8)
+
+def test_Latitude_warning(caplog):
+    precisecoordinates.Latitude(-10.3, precision=8)
+    assert 'WARNING' in caplog.text
+    assert 'precision exceeds maximum allowable value' in caplog.text
 
 
 def test_Coordinate_init():


### PR DESCRIPTION
Currently, when numbers are more precise that the maximum precision, an error is thrown. Instead, we should log a warning (that does not repeat).